### PR TITLE
refactor: 자동차 생성자에서 collaborator 생성하던 것 제거

### DIFF
--- a/src/main/java/racingcar/race/Car.java
+++ b/src/main/java/racingcar/race/Car.java
@@ -18,10 +18,9 @@ class Car {
         return new Car(carName, carPosition);
     }
 
-    static Car inStartingPositionWith(String name) {
+    static Car of(String name, Position position) {
         final Name carName = new Name(name);
-        final Position carPosition = Position.start();
-        return new Car(carName, carPosition);
+        return new Car(carName, position);
     }
 
     Name name() {

--- a/src/main/java/racingcar/race/Car.java
+++ b/src/main/java/racingcar/race/Car.java
@@ -12,12 +12,6 @@ class Car {
         this.position = position;
     }
 
-    static Car of(String name, int position) {
-        final Name carName = new Name(name);
-        final Position carPosition = new Position(position);
-        return new Car(carName, carPosition);
-    }
-
     static Car of(String name, Position position) {
         final Name carName = new Name(name);
         return new Car(carName, position);

--- a/src/main/java/racingcar/race/Race.java
+++ b/src/main/java/racingcar/race/Race.java
@@ -40,9 +40,10 @@ public final class Race {
     }
 
     static List<Car> mapCars(String... names) {
+        final Position position = Position.start();
         final List<Car> cars = new ArrayList<>();
         for (String name : names) {
-            cars.add(Car.inStartingPositionWith(name));
+            cars.add(Car.of(name, position));
         }
         return cars;
     }

--- a/src/test/java/racingcar/race/CarTest.java
+++ b/src/test/java/racingcar/race/CarTest.java
@@ -10,20 +10,22 @@ import racingcar.rule.Position;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CarTest {
+    private Position position = Position.start();
+    private Position otherPosition = new Position(3);
     private String name = "apple";
     private Car car;
 
     @BeforeEach
     void setUp() {
-        car = Car.inStartingPositionWith(name);
+        car = Car.of(name, position);
     }
 
     @DisplayName("다른 자동차와 위치 비교")
     @Test
     void comparePositionTo() {
         //given
-        Car sameCar = Car.inStartingPositionWith("same");
-        Car frontCar = Car.of("front", 3);
+        Car sameCar = Car.of("same", position);
+        Car frontCar = Car.of("front", otherPosition);
 
         //then
         assertThat(car.comparePositionTo(frontCar)).isEqualTo(-1);
@@ -34,11 +36,8 @@ class CarTest {
     @DisplayName("자동차가 해당 위치에 있으면 true")
     @Test
     void returnTrueWhenSamePosition() {
-        //given
-        Position samePosition = Position.start();
-
         //when
-        boolean actual = car.inPosition(samePosition);
+        boolean actual = car.inPosition(position);
 
         //then
         assertThat(actual).isTrue();
@@ -47,11 +46,8 @@ class CarTest {
     @DisplayName("자동차가 해당 위치가 아니면 false를 리턴한다")
     @Test
     void returnFalseWhenDifferencePosition() {
-        //given
-        Position other = new Position(3);
-
         //when
-        boolean actual = car.inPosition(other);
+        boolean actual = car.inPosition(otherPosition);
 
         //then
         assertThat(actual).isFalse();

--- a/src/test/java/racingcar/race/RaceTest.java
+++ b/src/test/java/racingcar/race/RaceTest.java
@@ -16,6 +16,9 @@ import static org.mockito.Mockito.*;
 
 class RaceTest {
 
+    private Position position = new Position(1);
+    private Position winnerPosition = new Position(3);
+
     @DisplayName("이름으로 자동차들을 만든다")
     @Test
     void create() {
@@ -34,9 +37,9 @@ class RaceTest {
     @Test
     void winner() {
         //given
-        Car car1 = Car.of("pobi", 1);
-        Car car2 = Car.of("crong", 3);
-        Car car3 = Car.of("honux", 2);
+        Car car1 = Car.of("pobi", position);
+        Car car2 = Car.of("crong", winnerPosition);
+        Car car3 = Car.of("honux", position);
         Race race = Race.from(car1, car2, car3);
 
         //when
@@ -50,9 +53,9 @@ class RaceTest {
     @Test
     void winners() {
         //given
-        Car car1 = Car.of("pobi", 3);
-        Car car2 = Car.of("crong", 4);
-        Car car3 = Car.of("honux", 4);
+        Car car1 = Car.of("pobi", position);
+        Car car2 = Car.of("crong", winnerPosition);
+        Car car3 = Car.of("honux", winnerPosition);
         Race race = Race.from(car1, car2, car3);
 
         //when
@@ -69,7 +72,7 @@ class RaceTest {
         Car car = mock(Car.class);
         MoveCount moveCount = MoveCount.fromString("5");
         given(car.name()).willReturn(new Name("pobi"));
-        given(car.position()).willReturn(new Position(3));
+        given(car.position()).willReturn(position);
 
         //when
         Race.from(car).startWith(moveCount);


### PR DESCRIPTION
### 느낀 점
* 가심비 좋은 리팩토링이었다
* 테스트 코드를 작성하면서 좀 이상하네라고만 생각하고 냄새를 전혀 못맡고 있었다
* 앞으로 객체를 mutable하게 바꾸게될 때는 해당 객체를 collaborator로 생성하는 곳을 같이 체크해봐야겠다

### 한 일
* `inStartingPositionWith` 정적 생성 메서드를 제거하고 모든 값을 받는 생성자를 사용하도록 변경
```java
// 제거(A)
static Car inStartingPositionWith(String name) {
        final Name carName = new Name(name);
        final Position carPosition = Position.start();
        return new Car(carName, carPosition);
}

// 제거(B)
static Car of(String name, String position) {
    final Name carName = new Name(name);
    final Position carPosition = new Position(name);
    return new Car(carName, carPosition);
}

// 사용(C)
static Car of(String name, Position position) {
    final Name carName = new Name(name);
    return new Car(carName, position);
}
```

### A 제거 이유
* `inStartingPositionWith` 생성자를 만들었던 이유는 사용하는 곳에서 더 편하고, 시작 값에 있는 자동차라는 의미를 주고싶어서였다.
  * 하지만 결과는 생성자 이름만 주절거릴 뿐이고 테스트 코드가 지저분해졌다 
* 왜 테스트 코드가 지저분해졌으며 `Name`은 내부에서 생성하면서 `Position`은 안되냐?
  *` Name`은 `Value object`고 `Position`은 아니다
  * 둘 다 처음엔 vo였지만 `Position`이 스스로 값을 증가하는 기능을 가짐으로써 mutable해졌다
    * 이 포인트는 `Car` 동작 테스트 시 `Position`도 관여하게 되므로 `Position`이 테스트 코드에 자주 등장하게 됨을 의미한다
    * `Name`은 그냥 값 설정용이고 immutable하므로 `Car` 테스트 로직에 등장하지 않는다

### B 제거 이유
* B는 A 생성자가 Position을 주입할 수 없으니 테스트 코드에서 테스트를 위해 열게됐다
  * 테스트에서 사용할 필요가 있는데도 테스트가 어렵다는 것은 sign이었다
  * 이 때 테스트용 B 생성자를 만드는 것이 아니라 A를 바꿨어야했음
* 새로운 C가 생성됐고 원시 값을 객체로 바꾸는 것이 전혀 어렵지 않았으므로 일관성을 위해 제거