### PR TITLE
refactor: 디미터 법칙을 지키기 위해 CarDto가 직접 Car를 받아서 변환

### DIFF
--- a/src/main/java/racingcar/race/CarDto.java
+++ b/src/main/java/racingcar/race/CarDto.java
@@ -1,19 +1,26 @@
 package racingcar.race;
 
-public class CarDto {
-    private final String name;
-    private final int position;
+import racingcar.rule.Name;
+import racingcar.rule.Position;
 
-    public CarDto(String name, int position) {
+public class CarDto {
+    private final Name name;
+    private final Position position;
+
+    private CarDto(Name name, Position position) {
         this.name = name;
         this.position = position;
     }
 
+    public static CarDto from(Car car) {
+        return new CarDto(car.name(), car.position());
+    }
+
     public int position() {
-        return position;
+        return position.get();
     }
 
     public String name() {
-        return name;
+        return name.get();
     }
 }

--- a/src/main/java/racingcar/race/Race.java
+++ b/src/main/java/racingcar/race/Race.java
@@ -62,13 +62,9 @@ public final class Race {
         for (Car car : cars) {
             final Energy energy = Energy.atRandom();
             car.moveBy(energy);
-            result.add(carDtoFrom(car));
+            result.add(CarDto.from(car));
         }
         return result;
-    }
-
-    private CarDto carDtoFrom(Car car) {
-        return new CarDto(car.name().get(), car.position().get());
     }
 
     public List<String> getWinner() {

--- a/src/test/java/racingcar/race/RaceTest.java
+++ b/src/test/java/racingcar/race/RaceTest.java
@@ -3,7 +3,6 @@ package racingcar.race;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import racingcar.rule.MoveCount;
-import racingcar.rule.Name;
 import racingcar.rule.Position;
 
 import java.util.List;
@@ -11,7 +10,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 class RaceTest {
@@ -71,8 +69,6 @@ class RaceTest {
         //given
         Car car = mock(Car.class);
         MoveCount moveCount = MoveCount.fromString("5");
-        given(car.name()).willReturn(new Name("pobi"));
-        given(car.position()).willReturn(position);
 
         //when
         Race.from(car).startWith(moveCount);


### PR DESCRIPTION
디미터 법칙은 잘 지켰다고 생각했는데 검색해 보니 2곳이 있었다.
두 곳 모두 원시 값을 포장한 객체에서 값을 꺼내는거니까 괜찮겠지?라고 생각했었다.
하지만 이것은 mock 객체를 사용할 때 문제가 발생한다.

Race 클래스 테스트 시 Car를 mocking할 경우 
```
car.name().get()
```
이 부분에서 NullPointException이 발생했었고 그래서 난 아래와 같이 희안하게 사용해야 했었다.
```
 given(car.name()).willReturn(new Name("pobi"));
```

문제는 NullPointException 때문에 처리한 것일뿐 테스트 코드에서 Name 클래스가 필요한게 아니라는 점이다.