### PR TITLE
feaet: 랜덤한 에너지를 에너지 팩토리에서 얻도록 변경

### DIFF
--- a/src/main/java/racingcar/Application.java
+++ b/src/main/java/racingcar/Application.java
@@ -2,6 +2,7 @@ package racingcar;
 
 import racingcar.game.Game;
 import racingcar.race.CarFactory;
+import racingcar.race.EnergyFactory;
 import racingcar.rule.Engine;
 import racingcar.rule.Position;
 import racingcar.view.InputView;
@@ -13,7 +14,8 @@ public class Application {
         final Message message = new Message();
         final InputView inputView = new InputView(message);
         final OutputView outputView = new OutputView(System.out, message);
-        final Engine engine = new Engine();
+        final EnergyFactory energyFactory = new EnergyFactory();
+        final Engine engine = new Engine(energyFactory);
         final Position position = Position.start();
         final CarFactory carFactory = CarFactory.from(engine, position); // TODO
 

--- a/src/main/java/racingcar/race/Car.java
+++ b/src/main/java/racingcar/race/Car.java
@@ -1,6 +1,9 @@
 package racingcar.race;
 
-import racingcar.rule.*;
+import racingcar.rule.Engine;
+import racingcar.rule.Move;
+import racingcar.rule.Name;
+import racingcar.rule.Position;
 
 public class Car {
     private final Engine engine;
@@ -34,8 +37,8 @@ public class Car {
         return this.position.equals(other);
     }
 
-    Position moveBy(Energy energy) {
-        final Move move = engine.powerBy(energy);
+    Position move() {
+        final Move move = engine.power();
         if (move.isForward()) {
             position.increase();
         }

--- a/src/main/java/racingcar/race/EnergyFactory.java
+++ b/src/main/java/racingcar/race/EnergyFactory.java
@@ -1,10 +1,12 @@
 package racingcar.race;
 
+import camp.nextstep.edu.missionutils.Randoms;
 import racingcar.rule.Energy;
 
 public class EnergyFactory {
 
     public Energy get() {
-        return Energy.atRandom(); // TODO
+        final int random = Randoms.pickNumberInRange(Energy.MIN, Energy.MAX);
+        return Energy.from(random);
     }
 }

--- a/src/main/java/racingcar/race/EnergyFactory.java
+++ b/src/main/java/racingcar/race/EnergyFactory.java
@@ -1,0 +1,10 @@
+package racingcar.race;
+
+import racingcar.rule.Energy;
+
+public class EnergyFactory {
+
+    public Energy get() {
+        return Energy.atRandom(); // TODO
+    }
+}

--- a/src/main/java/racingcar/race/Race.java
+++ b/src/main/java/racingcar/race/Race.java
@@ -59,7 +59,7 @@ public final class Race {
     public Winners getWinners() {
         final Winners winners = Winners.asMaxPosition(maxPosition());
         for (Car car : cars) {
-            winners.addIfMaxPosition(car);
+            winners.addIfMaxPosition(car.position(), car.name());
         }
         return winners;
     }

--- a/src/main/java/racingcar/race/Race.java
+++ b/src/main/java/racingcar/race/Race.java
@@ -1,6 +1,5 @@
 package racingcar.race;
 
-import racingcar.rule.Energy;
 import racingcar.rule.MoveCount;
 import racingcar.rule.Position;
 
@@ -51,8 +50,7 @@ public final class Race {
     private List<CarDto> move() {
         final List<CarDto> result = new ArrayList<>();
         for (Car car : cars) {
-            final Energy energy = Energy.atRandom();
-            car.moveBy(energy);
+            car.move();
             result.add(CarDto.from(car));
         }
         return result;

--- a/src/main/java/racingcar/race/Winners.java
+++ b/src/main/java/racingcar/race/Winners.java
@@ -22,11 +22,11 @@ public final class Winners {
         return winnerNames.size();
     }
 
-    public boolean addIfMaxPosition(Car car) {
-        if (!car.inPosition(maxPosition)) {
+    public boolean addIfMaxPosition(Position position, Name name) {
+        if (!position.equals(maxPosition)) {
             return false;
         }
-        return winnerNames.add(car.name());
+        return winnerNames.add(name);
     }
 
     public List<String> get() {

--- a/src/main/java/racingcar/rule/Energy.java
+++ b/src/main/java/racingcar/rule/Energy.java
@@ -1,12 +1,10 @@
 package racingcar.rule;
 
-import camp.nextstep.edu.missionutils.Randoms;
-
 import java.util.Objects;
 
 public class Energy implements Comparable<Energy> {
-    private static final int MIN = 0;
-    private static final int MAX = 9;
+    public static final int MIN = 0;
+    public static final int MAX = 9;
 
     private final int value;
 
@@ -24,11 +22,6 @@ public class Energy implements Comparable<Energy> {
 
     public static Energy from(int energy) {
         return new Energy(energy);
-    }
-
-    public static Energy atRandom() {
-        final int random = Randoms.pickNumberInRange(MIN, MAX);
-        return new Energy(random);
     }
 
     public int get() {
@@ -60,6 +53,4 @@ public class Energy implements Comparable<Energy> {
     public boolean isGraterThan(Energy other) {
         return this.compareTo(other) > 0;
     }
-
-
 }

--- a/src/main/java/racingcar/rule/Energy.java
+++ b/src/main/java/racingcar/rule/Energy.java
@@ -2,7 +2,7 @@ package racingcar.rule;
 
 import java.util.Objects;
 
-public class Energy implements Comparable<Energy> {
+public class Energy {
     public static final int MIN = 0;
     public static final int MAX = 9;
 
@@ -28,6 +28,14 @@ public class Energy implements Comparable<Energy> {
         return value;
     }
 
+    public boolean isLessThan(Energy other) {
+        return this.value < other.value;
+    }
+
+    public boolean isGraterThan(Energy other) {
+        return this.value > other.value;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -39,18 +47,5 @@ public class Energy implements Comparable<Energy> {
     @Override
     public int hashCode() {
         return Objects.hash(value);
-    }
-
-    @Override
-    public int compareTo(Energy other) {
-        return Integer.compare(this.value, other.value);
-    }
-
-    public boolean isLessThan(Energy other) {
-        return this.compareTo(other) < 0;
-    }
-
-    public boolean isGraterThan(Energy other) {
-        return this.compareTo(other) > 0;
     }
 }

--- a/src/main/java/racingcar/rule/Engine.java
+++ b/src/main/java/racingcar/rule/Engine.java
@@ -1,9 +1,17 @@
 package racingcar.rule;
 
+import racingcar.race.EnergyFactory;
+
 public class Engine {
     public static final Energy FORWARD_ENERGY = Energy.from(4);
+    private final EnergyFactory energyFactory;
 
-    public Move powerBy(Energy energy) {
+    public Engine(EnergyFactory energyFactory) {
+        this.energyFactory = energyFactory;
+    }
+
+    public Move power() {
+        final Energy energy = energyFactory.get();
         if (energy.isLessThan(FORWARD_ENERGY)) {
             return Move.STOP;
         }

--- a/src/test/java/racingcar/game/GameTest.java
+++ b/src/test/java/racingcar/game/GameTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import racingcar.race.CarFactory;
+import racingcar.race.EnergyFactory;
 import racingcar.rule.Engine;
 import racingcar.rule.Position;
 import racingcar.view.InputView;
@@ -15,7 +16,8 @@ import static org.mockito.Mockito.*;
 class GameTest {
     InputView inputView = mock(InputView.class);
     OutputView outputView = mock(OutputView.class);
-    Engine engine = new Engine();
+    EnergyFactory energyFactory = new EnergyFactory();
+    Engine engine = new Engine(energyFactory);
     Position position = Position.start();
     CarFactory carFactory = CarFactory.from(engine, position); // TODO
     Game game = new Game(inputView, outputView, carFactory);

--- a/src/test/java/racingcar/race/CarFactoryTest.java
+++ b/src/test/java/racingcar/race/CarFactoryTest.java
@@ -11,11 +11,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CarFactoryTest {
 
+    // TODO
     @DisplayName("입력받은 문자열로 자동차를 만든다")
     @Test
     void factory() {
         //given
-        Engine engine = new Engine();
+        EnergyFactory energyFactory = new EnergyFactory();
+        Engine engine = new Engine(energyFactory);
         Position position = Position.start();
         String model = "pobi,crong,honux";
 

--- a/src/test/java/racingcar/race/CarTest.java
+++ b/src/test/java/racingcar/race/CarTest.java
@@ -3,14 +3,16 @@ package racingcar.race;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import racingcar.rule.Energy;
 import racingcar.rule.Engine;
+import racingcar.rule.Move;
 import racingcar.rule.Position;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 class CarTest {
-    private Engine engine = new Engine();
+    private Engine engine = mock(Engine.class);
     private Position position = Position.start();
     private Position otherPosition = new Position(3);
     private String name = "apple";
@@ -58,10 +60,10 @@ class CarTest {
     @Test
     void stopOnce() {
         //given
-        Energy stop = Energy.from(Engine.FORWARD_ENERGY.get() - 1);
+        given(engine.power()).willReturn(Move.STOP);
 
         //when
-        Position position = car.moveBy(stop);
+        Position position = car.move();
 
         //then
         assertThat(position.get()).isZero();
@@ -71,11 +73,11 @@ class CarTest {
     @Test
     void forwardTwice() {
         //given
-        Energy forward = Engine.FORWARD_ENERGY;
+        given(engine.power()).willReturn(Move.FORWARD);
 
         //when
-        Position firstPosition = car.moveBy(forward);
-        Position secondsPosition = car.moveBy(forward);
+        Position firstPosition = car.move();
+        Position secondsPosition = car.move();
 
         //then
         assertThat(firstPosition.get()).isEqualTo(1);

--- a/src/test/java/racingcar/race/RaceTest.java
+++ b/src/test/java/racingcar/race/RaceTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 class RaceTest {
@@ -62,7 +61,7 @@ class RaceTest {
         Race.from(car).startWith(moveCount);
 
         //then
-        verify(car, times(moveCount.get())).moveBy(any());
+        verify(car, times(moveCount.get())).move();
     }
 
 
@@ -108,7 +107,8 @@ class RaceTest {
     }
 
     private Car createCar(Position position, String name) {
-        final Engine engine = new Engine();
+        final EnergyFactory energyFactory = new EnergyFactory();
+        final Engine engine = new Engine(energyFactory);
         return Car.of(engine, position, name); // TODO
     }
 }

--- a/src/test/java/racingcar/race/WinnersTest.java
+++ b/src/test/java/racingcar/race/WinnersTest.java
@@ -2,7 +2,7 @@ package racingcar.race;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import racingcar.rule.Engine;
+import racingcar.rule.Name;
 import racingcar.rule.Position;
 
 import java.util.List;
@@ -10,18 +10,15 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class WinnersTest {
-    private EnergyFactory energyFactory = new EnergyFactory();
-    private Engine engine = new Engine(energyFactory);
     private Position winningPosition = new Position(5);
-    private String winningCarName = "pobi";
-    private Car winningCar = Car.of(engine, winningPosition, winningCarName);
+    private Name winningCarName = new Name("pobi");
     private Winners winners = Winners.asMaxPosition(winningPosition);
 
     @DisplayName("자동차의 거리가 레이싱 최대 거리이면 값이 추가된다")
     @Test
     void addReturnTrueWhenWinners() {
         //when
-        boolean actual = winners.addIfMaxPosition(winningCar);
+        boolean actual = winners.addIfMaxPosition(winningPosition, winningCarName);
 
         //then
         assertThat(actual).isTrue();
@@ -31,10 +28,11 @@ class WinnersTest {
     @Test
     void addReturnFalseWhenNotWinners() {
         //given
-        Car unmovedCar = Car.of(engine, Position.start(), "user");
+        Position lessPosition = Position.start();
+        Name name = new Name("user");
 
         //when
-        boolean actual = winners.addIfMaxPosition(unmovedCar);
+        boolean actual = winners.addIfMaxPosition(lessPosition, name);
 
         //then
         assertThat(actual).isFalse();
@@ -44,7 +42,7 @@ class WinnersTest {
     @Test
     void size() {
         //when
-        winners.addIfMaxPosition(winningCar);
+        winners.addIfMaxPosition(winningPosition, winningCarName);
 
         //then
         assertThat(winners.size()).isOne();
@@ -54,11 +52,11 @@ class WinnersTest {
     @Test
     void get() {
         //when
-        winners.addIfMaxPosition(winningCar);
+        winners.addIfMaxPosition(winningPosition, winningCarName);
         List<String> actual = winners.get();
 
         //then
-        assertThat(actual).containsOnly(winningCarName);
+        assertThat(actual).containsOnly(winningCarName.get());
     }
 
     @DisplayName("우승자 이름 목록은 항상 새로운 목록에 담아 반환한다")

--- a/src/test/java/racingcar/race/WinnersTest.java
+++ b/src/test/java/racingcar/race/WinnersTest.java
@@ -10,7 +10,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class WinnersTest {
-    private Engine engine = new Engine();
+    private EnergyFactory energyFactory = new EnergyFactory();
+    private Engine engine = new Engine(energyFactory);
     private Position winningPosition = new Position(5);
     private String winningCarName = "pobi";
     private Car winningCar = Car.of(engine, winningPosition, winningCarName);

--- a/src/test/java/racingcar/rule/EnergyTest.java
+++ b/src/test/java/racingcar/rule/EnergyTest.java
@@ -68,9 +68,8 @@ class EnergyTest {
         assertThat(actual).isTrue();
     }
 
-    @DisplayName("natural ordering과 equals가 일치하도록 권장된다")
     @Test
-    void comparableAndEquality() {
+    void equality() {
         //given
         int sameNumber = 1;
 
@@ -81,7 +80,6 @@ class EnergyTest {
         //then
         assertThat(energy)
                 .isEqualTo(other)
-                .hasSameHashCodeAs(other)
-                .isEqualByComparingTo(other);
+                .hasSameHashCodeAs(other);
     }
 }

--- a/src/test/java/racingcar/rule/EngineTest.java
+++ b/src/test/java/racingcar/rule/EngineTest.java
@@ -2,36 +2,38 @@ package racingcar.rule;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import racingcar.race.EnergyFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 class EngineTest {
-    private Engine engine = new Engine();
-    private int ENGINE_FORWARD_ENERGY = 4;
+    private EnergyFactory energyFactory = mock(EnergyFactory.class);
+    private Engine engine = new Engine(energyFactory);
 
-    @DisplayName("에너지가 4 이상이면 전진한다")
+    @DisplayName("최소 전진 에너지 이상이면 전진한다")
     @Test
     void forwardWhenMoreThan4() {
         //given
-        int moreThan4 = ENGINE_FORWARD_ENERGY;
+        given(energyFactory.get()).willReturn(Engine.FORWARD_ENERGY);
 
         //when
-        Energy energy = Energy.from(moreThan4);
-        Move move = engine.powerBy(energy);
+        Move move = engine.power();
 
         //then
         assertThat(move.isForward()).isTrue();
     }
 
-    @DisplayName("에너지가 4 미만이면 멈춤이다")
+    @DisplayName("최소 전진 에너지 미만이면 멈춤이다")
     @Test
     void stopWhenLessThan4() {
         //given
-        int lessThan4 = ENGINE_FORWARD_ENERGY - 1;
+        Energy lessForwardEnergy = Energy.from(Engine.FORWARD_ENERGY.get() - 1);
+        given(energyFactory.get()).willReturn(lessForwardEnergy);
 
         //when
-        Energy energy = Energy.from(lessThan4);
-        Move move = engine.powerBy(energy);
+        Move move = engine.power();
 
         //then
         assertThat(move.isStop()).isTrue();


### PR DESCRIPTION
### 한 것
- 기존: `Race`에서 랜덤한 에너지를 만들어 `Car`에 전달하면 `Car`는 `Engine`에게 전달
- 변경: `Engine`이 생성될 때 `EnergyFactory`를 주입받아 직접 사용하고, 팩토리가 Random 값 생성

Before
```java
// Race.class
public List move() {
    final Energy energy = Energy.atRandom();
    car.moveBy(energy);
    ...
}


// Car.class
public Position moveBy(Energy energy) {
    final Move move = engine.powerBy(energy);
     ...
}
```

After
```java
// Race.class
public List move() {
    car.move();
    ...
}


// Car.class
public Position move() {
    final Move move = engine.power();
     ...
}

// Engine.class
public Move power() {
    final Energy energy = energyFactory.get();
     ...
}
```

### 고민 됨
자동차 이동 시도마다 새로운 랜덤 값이 생성되어야 하므로 에너지를 생성해주는 `Factory`가 필요했다
- 기존엔 클래스가 늘어나는게 싫어서 Race의 for문에서 랜덤 값을 생성했지만 자동차 경주가 Energy를 아는 것은 이상하다

그럼 EnergyFactory는 만들었지만 어떻게 Engine까지 전달해야 할까?
![image](https://user-images.githubusercontent.com/75404713/165692495-8f9d4314-6d9f-40c0-9ebe-31beac7ac4ce.png)

위와 같이 생성과 사용까지 많은 클래스를 거쳐야하기 때문에 중간에 전달하는 클래스들이 전부 Factory를 알아야될 수 있다

![image](https://user-images.githubusercontent.com/75404713/165692879-3833df6f-0257-492e-8b65-b9ce6ab6749a.png)

그래서 `Engine`이나 `Car` 둘 중 하나가 적합해보였는데 고민이 된 이유는

- `Car`에서 생성자로 EnergyFactory를 받는 경우
  - 장점: 테스트 코드에서 mocking을 Car에서 한번만 하면 됨. Engine 테스트가 쉬움 
  - 단점: Car가 EnergyFactory와 Energy를 알아야됨
- `Engine`에서 생성자로  EnergyFactory를 받는 경우
  - 장점: `Energy`를 `Engine`만 알게됨
  - 단점: mockig을 Car와 Engine에서 두 번 해야됨

( mocking이 필요한 이유는 Energy가 랜덤 값이라서)

결국 모르겠어서 둘 다 한번씩 바꿔봤는데 장단점이 엄청 크지 않고 비슷비슷했다
- 엔진을 사용하는 Car에서 직접 에너지를 주입해줘야되나?
- 그럼 직접 사용하는게 아니라 전달만 하는거니까 너무 많이 알게되는 것 아닌가?

이렇게 엄청 고민하다가 Car와 Energy 모두 Factory를 사용할 것이므로 Engine에서 직접 받는 걸로 일단 골랐다