### PR TITLE
refactor: Race → RacingCars로 클래스명 변경 및 역할 축소하기

### DIFF
--- a/src/main/java/racingcar/game/Game.java
+++ b/src/main/java/racingcar/game/Game.java
@@ -23,23 +23,23 @@ public class Game {
     }
 
     public void play() {
-        final Race race = createRace();
+        final RacingCars racingCars = createRacingCars();
         final MoveCount moveCount = createMoveCount();
-        final List<List<CarDto>> result = race.startWith(moveCount);
+        final List<List<CarDto>> result = racingCars.startWith(moveCount);
         outputView.printResult(result);
-        final WinnersDto winners = race.getWinners();
+        final WinnersDto winners = racingCars.getWinners();
         outputView.printWinners(winners);
     }
 
-    Race createRace() {
+    RacingCars createRacingCars() {
         try {
             final String inputNames = inputView.inputCarsNames();
             final List<Name> delimitNames = nameDelimiter.delimit(inputNames);
             final List<Car> cars = carFactory.create(delimitNames);
-            return Race.from(cars);
+            return RacingCars.from(cars);
         } catch (IllegalArgumentException e) {
             outputView.printError(e.getMessage());
-            return createRace();
+            return createRacingCars();
         }
     }
 

--- a/src/main/java/racingcar/game/Game.java
+++ b/src/main/java/racingcar/game/Game.java
@@ -7,6 +7,7 @@ import racingcar.rule.NameDelimiter;
 import racingcar.view.InputView;
 import racingcar.view.OutputView;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class Game {
@@ -25,7 +26,7 @@ public class Game {
     public void play() {
         final RacingCars racingCars = createRacingCars();
         final MoveCount moveCount = createMoveCount();
-        final List<List<CarDto>> result = racingCars.startWith(moveCount);
+        final List<List<CarDto>> result = startRaceWith(racingCars, moveCount);
         outputView.printResult(result);
         final WinnersDto winners = racingCars.getWinners();
         outputView.printWinners(winners);
@@ -51,5 +52,14 @@ public class Game {
             outputView.printError(e.getMessage());
             return createMoveCount();
         }
+    }
+
+    List<List<CarDto>> startRaceWith(RacingCars racingCars, MoveCount moveCount) {
+        final List<List<CarDto>> result = new ArrayList<>();
+        for (int i = 0; i < moveCount.get(); i++) {
+            final List<CarDto> moveCar = racingCars.move();
+            result.add(moveCar);
+        }
+        return result;
     }
 }

--- a/src/main/java/racingcar/race/RacingCars.java
+++ b/src/main/java/racingcar/race/RacingCars.java
@@ -7,10 +7,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public final class Race {
+public final class RacingCars {
     private final List<Car> cars;
 
-    private Race(List<Car> cars) {
+    private RacingCars(List<Car> cars) {
         validateMinSize(cars);
         validateMaxSize(cars);
         this.cars = cars;
@@ -29,12 +29,12 @@ public final class Race {
         }
     }
 
-    public static Race from(List<Car> cars) {
-        return new Race(cars);
+    public static RacingCars from(List<Car> cars) {
+        return new RacingCars(cars);
     }
 
-    public static Race from(Car... cars) {
-        return Race.from(Arrays.asList(cars));
+    public static RacingCars from(Car... cars) {
+        return RacingCars.from(Arrays.asList(cars));
     }
 
     public List<List<CarDto>> startWith(MoveCount moveCount) {

--- a/src/main/java/racingcar/race/RacingCars.java
+++ b/src/main/java/racingcar/race/RacingCars.java
@@ -1,6 +1,5 @@
 package racingcar.race;
 
-import racingcar.rule.MoveCount;
 import racingcar.rule.Name;
 
 import java.util.ArrayList;
@@ -33,20 +32,11 @@ public final class RacingCars {
         return new RacingCars(cars);
     }
 
-    public static RacingCars from(Car... cars) {
+    public static RacingCars of(Car... cars) {
         return RacingCars.from(Arrays.asList(cars));
     }
 
-    public List<List<CarDto>> startWith(MoveCount moveCount) {
-        final List<List<CarDto>> result = new ArrayList<>();
-        for (int i = 0; i < moveCount.get(); i++) {
-            final List<CarDto> moveCar = move();
-            result.add(moveCar);
-        }
-        return result;
-    }
-
-    private List<CarDto> move() {
+    public List<CarDto> move() {
         final List<CarDto> result = new ArrayList<>();
         for (Car car : cars) {
             car.move();
@@ -55,6 +45,7 @@ public final class RacingCars {
         return result;
     }
 
+    // TODO: Game으로 옮기기 -> CarDto와 getWinners 모두 자동차의 현재 위치, 이름을 필요로 한다
     public WinnersDto getWinners() {
         final Winners winners = new Winners();
         final List<Name> winnerNames = winners.determineFrom(cars);

--- a/src/test/java/racingcar/game/GameTest.java
+++ b/src/test/java/racingcar/game/GameTest.java
@@ -42,7 +42,7 @@ class GameTest {
         given(inputView.inputCarsNames()).willReturn("sixTxt", " ", "valid");
 
         //when
-        game.createRace();
+        game.createRacingCars();
 
         //then
         verify(inputView, times(3)).inputCarsNames();

--- a/src/test/java/racingcar/game/GameTest.java
+++ b/src/test/java/racingcar/game/GameTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import racingcar.race.CarFactory;
+import racingcar.race.RacingCars;
+import racingcar.rule.MoveCount;
 import racingcar.rule.NameDelimiter;
 import racingcar.view.InputView;
 import racingcar.view.OutputView;
@@ -59,5 +61,19 @@ class GameTest {
 
         //then
         verify(inputView, times(3)).inputMoveCount();
+    }
+
+    @DisplayName("이동 횟수만큼 자동차가 움직인다")
+    @Test
+    void startRaceWith() {
+        //given
+        RacingCars racingCars = mock(RacingCars.class);
+        MoveCount moveCount = MoveCount.fromString("5");
+
+        //when
+        game.startRaceWith(racingCars, moveCount);
+
+        //then
+        verify(racingCars, times(moveCount.get())).move();
     }
 }

--- a/src/test/java/racingcar/race/RacingCarsTest.java
+++ b/src/test/java/racingcar/race/RacingCarsTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-class RaceTest {
+class RacingCarsTest {
 
     @DisplayName("이동 횟수만큼 자동차가 움직인다")
     @Test
@@ -22,7 +22,7 @@ class RaceTest {
         MoveCount moveCount = MoveCount.fromString("5");
 
         //when
-        Race.from(car).startWith(moveCount);
+        RacingCars.from(car).startWith(moveCount);
 
         //then
         verify(car, times(moveCount.get())).move();
@@ -35,7 +35,7 @@ class RaceTest {
         List<Car> empty = Collections.emptyList();
 
         //when
-        Throwable thrown = catchThrowable(() -> Race.from(empty));
+        Throwable thrown = catchThrowable(() -> RacingCars.from(empty));
 
         //then
         assertThat(thrown)
@@ -52,7 +52,7 @@ class RaceTest {
         given(cars.size()).willReturn(GRATER_THAN_CAR_LIST_SIZE);
 
         //when
-        Throwable thrown = catchThrowable(() -> Race.from(cars));
+        Throwable thrown = catchThrowable(() -> RacingCars.from(cars));
 
         //then
         assertThat(thrown)

--- a/src/test/java/racingcar/race/RacingCarsTest.java
+++ b/src/test/java/racingcar/race/RacingCarsTest.java
@@ -2,7 +2,6 @@ package racingcar.race;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import racingcar.rule.MoveCount;
 
 import java.util.Collections;
 import java.util.List;
@@ -10,23 +9,10 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class RacingCarsTest {
-
-    @DisplayName("이동 횟수만큼 자동차가 움직인다")
-    @Test
-    void startRaceWith() {
-        //given
-        Car car = mock(Car.class);
-        MoveCount moveCount = MoveCount.fromString("5");
-
-        //when
-        RacingCars.from(car).startWith(moveCount);
-
-        //then
-        verify(car, times(moveCount.get())).move();
-    }
 
     @DisplayName("경주할 자동차가 없는 경우 예외가 발생한다")
     @Test
@@ -45,7 +31,7 @@ class RacingCarsTest {
 
     @DisplayName("경주할 자동차가 최대 값을 초과하는 경우 예외가 발생한다")
     @Test
-    void thrownExceptionWhenGraterThanMaxSize() {
+    void throwExceptionWhenGraterThanMaxSize() {
         //given
         int GRATER_THAN_CAR_LIST_SIZE = 10 + 1;
         List<Car> cars = mock(List.class);
@@ -58,5 +44,19 @@ class RacingCarsTest {
         assertThat(thrown)
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("경주할 자동차는 10대 이하여야 한다.");
+    }
+
+    @DisplayName("자동차들이 움직인다")
+    @Test
+    void move() {
+        //given
+        Car car = mock(Car.class);
+
+        //when
+        RacingCars racingCars = RacingCars.of(car);
+        racingCars.move();
+
+        //then
+        verify(car).move();
     }
 }


### PR DESCRIPTION
### 한 것
* Race → RacingCar로 클래스명을 변경하여 경주할 자동차들을 나타내는 역할만 하도록 한다.

### 기존 문제점
기존에는 레이스 경주 자체를 나타내고 싶었는데 몇 가지 문제점이 있었다.
* Race와 Game 클래스의 개념이 모호함 →  사실 RaceGame이 아닌가?
* Race는 Cars가 아닌가? →  List<Car> 필드만 가지고 있는 일급 컬렉션이니까

### 느낀 것
* 기존에 개발하면서 Race가 Cars와 MoveCount 2개의 필드를 가져야하는게 아닌가?싶었지만 일급 컬렉션은 해당 필드 하나만 있어야된다고 본 것 같아서 Cars + Race 두 개의 클래스가 만들어지는게 부담스러웠다. 
  * 그래서 하나로 꾸역꾸역 썼더니 하는일이 정말 모호해져버렸다.
* 진짜 그냥 작게 일단 쪼개고 클래스 갯수가 너무 많아지는 부담은 개발이 다 끝나고 합치는 것으로 하는게 설계가 훨씬 더 유연해질 것 같다

### 해야할 것
* [저번 리팩토링](https://github.com/viiviii/java-racingcar-precourse/pull/20)부터 Race 클래스의 하는 일을 축소하고 있는데 이번 작업까지 해보니 예전에 고민하다 멈춰놓은 CarDto의 이상한 점이 보인다.
* 이 부분을 해결하면 RacingCars에 불필요한 `getWinners()`까지 Game으로 옮길 수 있다