### PR TITLE
refactor: Winners를 우승 심판자로 변경하고 DI 받도록 변경

### DIFF
--- a/src/main/java/racingcar/Application.java
+++ b/src/main/java/racingcar/Application.java
@@ -2,6 +2,7 @@ package racingcar;
 
 import racingcar.game.Game;
 import racingcar.race.CarFactory;
+import racingcar.race.WinnersReferee;
 import racingcar.rule.NameDelimiter;
 import racingcar.view.InputView;
 import racingcar.view.OutputView;
@@ -14,6 +15,9 @@ public class Application {
         final OutputView outputView = new OutputView(System.out, message);
         final CarFactory carFactory = CarFactory.fromDefault();
         final NameDelimiter nameDelimiter = new NameDelimiter();
-        new Game(inputView, outputView, carFactory, nameDelimiter).play();
+        final WinnersReferee winnersReferee = new WinnersReferee();
+        // TODO: 부자다 부자
+        new Game(inputView, outputView, carFactory, nameDelimiter, winnersReferee)
+                .play();
     }
 }

--- a/src/main/java/racingcar/game/Game.java
+++ b/src/main/java/racingcar/game/Game.java
@@ -64,7 +64,7 @@ public class Game {
     }
 
     public WinnersDto determineWinners(MoveRecords moveRecords) {
-        final Winners winners = new Winners();
+        final WinnersReferee winners = new WinnersReferee();
         final List<Name> winnerNames = winners.determineFrom(moveRecords);
         return WinnersDto.from(winnerNames);
     }

--- a/src/main/java/racingcar/game/Game.java
+++ b/src/main/java/racingcar/game/Game.java
@@ -15,12 +15,14 @@ public class Game {
     private final OutputView outputView;
     private final CarFactory carFactory;
     private final NameDelimiter nameDelimiter;
+    private final WinnersReferee winnersReferee;
 
-    public Game(InputView inputView, OutputView outputView, CarFactory carFactory, NameDelimiter nameDelimiter) {
+    public Game(InputView inputView, OutputView outputView, CarFactory carFactory, NameDelimiter nameDelimiter, WinnersReferee winners) {
         this.inputView = inputView;
         this.outputView = outputView;
         this.carFactory = carFactory;
         this.nameDelimiter = nameDelimiter;
+        this.winnersReferee = winners;
     }
 
     public void play() {
@@ -62,10 +64,9 @@ public class Game {
         }
         return result;
     }
-
+    
     public WinnersDto determineWinners(MoveRecords moveRecords) {
-        final WinnersReferee winners = new WinnersReferee();
-        final List<Name> winnerNames = winners.determineFrom(moveRecords);
+        final List<Name> winnerNames = winnersReferee.determineFrom(moveRecords);
         return WinnersDto.from(winnerNames);
     }
 }

--- a/src/main/java/racingcar/game/Game.java
+++ b/src/main/java/racingcar/game/Game.java
@@ -28,7 +28,7 @@ public class Game {
         final MoveCount moveCount = createMoveCount();
         final List<MoveRecords> result = startRaceWith(racingCars, moveCount);
         outputView.printResult(result);
-        final WinnersDto winners = racingCars.getWinners();
+        final WinnersDto winners = determineWinners(result.get(result.size() - 1)); // TODO
         outputView.printWinners(winners);
     }
 
@@ -61,5 +61,11 @@ public class Game {
             result.add(moveRecords);
         }
         return result;
+    }
+
+    public WinnersDto determineWinners(MoveRecords moveRecords) {
+        final Winners winners = new Winners();
+        final List<Name> winnerNames = winners.determineFrom(moveRecords);
+        return WinnersDto.from(winnerNames);
     }
 }

--- a/src/main/java/racingcar/race/MoveRecords.java
+++ b/src/main/java/racingcar/race/MoveRecords.java
@@ -3,6 +3,7 @@ package racingcar.race;
 import racingcar.rule.Name;
 import racingcar.rule.Position;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,5 +22,9 @@ public final class MoveRecords {
 
     public Iterable<Name> allNames() {
         return records.keySet();
+    }
+
+    public Position maxPosition() {
+        return Collections.max(records.values());
     }
 }

--- a/src/main/java/racingcar/race/RacingCars.java
+++ b/src/main/java/racingcar/race/RacingCars.java
@@ -1,6 +1,5 @@
 package racingcar.race;
 
-import racingcar.rule.Name;
 import racingcar.rule.Position;
 
 import java.util.Arrays;
@@ -44,12 +43,5 @@ public final class RacingCars {
             records.recordOf(car.name(), movedPosition);
         }
         return records;
-    }
-
-    // TODO: Game으로 옮기기 -> CarDto와 getWinners 모두 자동차의 현재 위치, 이름을 필요로 한다
-    public WinnersDto getWinners() {
-        final Winners winners = new Winners();
-        final List<Name> winnerNames = winners.determineFrom(cars);
-        return WinnersDto.from(winnerNames);
     }
 }

--- a/src/main/java/racingcar/race/Winners.java
+++ b/src/main/java/racingcar/race/Winners.java
@@ -3,42 +3,21 @@ package racingcar.race;
 import racingcar.rule.Name;
 import racingcar.rule.Position;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class Winners {
-    private Map<Position, Names> record = new HashMap<>();
 
-    public List<Name> determineFrom(List<Car> cars) {
-        doRecord(cars);
-        return names(winningPosition()).toList();
-    }
-
-    private void doRecord(List<Car> cars) {
-        for (Car car : cars) {
-            final Position position = car.position();
-            final Names names = names(position);
-            record.put(position, names.add(car.name()));
+    // TODO
+    public List<Name> determineFrom(MoveRecords moveRecords) {
+        final Position winningPosition = moveRecords.maxPosition();
+        final List<Name> winners = new ArrayList<>();
+        for (Name name : moveRecords.allNames()) {
+            Position position = moveRecords.positionBy(name);
+            if (position.equals(winningPosition)) {
+                winners.add(name);
+            }
         }
-    }
-
-    private Names names(Position position) {
-        return record.getOrDefault(position, new Names());
-    }
-
-    Position winningPosition() {
-        return Collections.max(record.keySet());
-    }
-
-    private static final class Names {
-        private List<Name> names = new ArrayList<>();
-
-        private Names add(Name name) {
-            names.add(name);
-            return this;
-        }
-
-        private List<Name> toList() {
-            return new ArrayList<>(names);
-        }
+        return winners;
     }
 }

--- a/src/main/java/racingcar/race/WinnersReferee.java
+++ b/src/main/java/racingcar/race/WinnersReferee.java
@@ -6,7 +6,7 @@ import racingcar.rule.Position;
 import java.util.ArrayList;
 import java.util.List;
 
-public final class Winners {
+public final class WinnersReferee {
 
     // TODO
     public List<Name> determineFrom(MoveRecords moveRecords) {

--- a/src/test/java/racingcar/game/GameTest.java
+++ b/src/test/java/racingcar/game/GameTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import racingcar.race.CarFactory;
 import racingcar.race.RacingCars;
+import racingcar.race.WinnersReferee;
 import racingcar.rule.MoveCount;
 import racingcar.rule.NameDelimiter;
 import racingcar.view.InputView;
@@ -14,11 +15,12 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 class GameTest {
-    InputView inputView = mock(InputView.class);
-    OutputView outputView = mock(OutputView.class);
-    CarFactory carFactory = CarFactory.fromDefault();
-    NameDelimiter nameDelimiter = new NameDelimiter();
-    Game game = new Game(inputView, outputView, carFactory, nameDelimiter);
+    private InputView inputView = mock(InputView.class);
+    private OutputView outputView = mock(OutputView.class);
+    private CarFactory carFactory = CarFactory.fromDefault();
+    private NameDelimiter nameDelimiter = new NameDelimiter();
+    private WinnersReferee winnersReferee = new WinnersReferee();
+    private Game game = new Game(inputView, outputView, carFactory, nameDelimiter, winnersReferee);
 
     @DisplayName("자동차 경주 게임 플레이")
     @Test

--- a/src/test/java/racingcar/race/MoveRecordsTest.java
+++ b/src/test/java/racingcar/race/MoveRecordsTest.java
@@ -72,4 +72,21 @@ class MoveRecordsTest {
         //then
         assertThat(names).containsExactlyInAnyOrder(name1, name2);
     }
+
+
+    @DisplayName("기록된 최대 위치를 구할 수 있다")
+    @Test
+    void maxPosition() {
+        //given
+        Position expectedMaxPosition = new Position(5);
+        MoveRecords moveRecords = new MoveRecords();
+
+        //when
+        moveRecords.recordOf(new Name("pobi"), expectedMaxPosition);
+        moveRecords.recordOf(new Name("honux"), Position.start());
+        Position actual = moveRecords.maxPosition();
+
+        //then
+        assertThat(actual).isEqualTo(expectedMaxPosition);
+    }
 }

--- a/src/test/java/racingcar/race/WinnersRefereeTest.java
+++ b/src/test/java/racingcar/race/WinnersRefereeTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class WinnersTest {
+class WinnersRefereeTest {
 
     @DisplayName("가장 먼 위치의 자동차가 우승이다")
     @Test
@@ -20,7 +20,7 @@ class WinnersTest {
         moveRecords.recordOf(new Name("pobi"), new Position(1));
         moveRecords.recordOf(expectedWinner, new Position(9));
         moveRecords.recordOf(new Name("honux"), new Position(3));
-        Winners winners = new Winners();
+        WinnersReferee winners = new WinnersReferee();
 
         //when
         List<Name> winnerNames = winners.determineFrom(moveRecords);

--- a/src/test/java/racingcar/race/WinnersTest.java
+++ b/src/test/java/racingcar/race/WinnersTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import racingcar.rule.Name;
 import racingcar.rule.Position;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,16 +15,17 @@ class WinnersTest {
     @Test
     void winners() {
         //given
+        Name expectedWinner = new Name("crong");
+        MoveRecords moveRecords = new MoveRecords();
+        moveRecords.recordOf(new Name("pobi"), new Position(1));
+        moveRecords.recordOf(expectedWinner, new Position(9));
+        moveRecords.recordOf(new Name("honux"), new Position(3));
         Winners winners = new Winners();
-        CarFactory carFactory = CarFactory.fromDefault();
-        Car car1 = carFactory.of(new Position(1), "pobi");
-        Car car2 = carFactory.of(new Position(9), "crong");
-        Car car3 = carFactory.of(new Position(3), "honux");
 
         //when
-        List<Name> winnerNames = winners.determineFrom(Arrays.asList(car1, car2, car3));
+        List<Name> winnerNames = winners.determineFrom(moveRecords);
 
         //then
-        assertThat(winnerNames).containsOnly(car2.name());
+        assertThat(winnerNames).containsOnly(expectedWinner);
     }
 }


### PR DESCRIPTION
### 한 일
- Winners를 WinnersReferee로 변경했다
  - WinnersDto가 진짜 Winners고 기존의 Winners는 우승자를 선별하는 일을 하므로 WinnersReferee인게 아닐까?
- 우승자 선별을 MoveRecods를 사용하도록 하여 로직을 Game으로 이동시켰다

### TODO
- 리팩토링을 하다 말았다
- 이유는 ApplicationTest의 테스트 케이스 하나가 종종 실패하는걸 목격해버렸다ㅠ