### PR TITLE
refactor: 우승 조건은 WinnersReferee가 담당하기

### DIFF
--- a/src/main/java/racingcar/race/MoveRecords.java
+++ b/src/main/java/racingcar/race/MoveRecords.java
@@ -3,14 +3,14 @@ package racingcar.race;
 import racingcar.rule.Name;
 import racingcar.rule.Position;
 
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public final class MoveRecords {
     private Map<Name, Position> records = new HashMap<>();
 
-    // TODO: recordOf 이런 값이 변하는 메서드는 최대한 숨기고 싶어
     public boolean recordOf(Name name, Position position) {
         records.put(name, position);
         return records.containsKey(name);
@@ -20,11 +20,11 @@ public final class MoveRecords {
         return records.get(name);
     }
 
-    public Iterable<Name> allNames() {
+    public Set<Name> allNames() {
         return records.keySet();
     }
 
-    public Position maxPosition() {
-        return Collections.max(records.values());
+    public Collection<Position> allPositions() {
+        return records.values();
     }
 }

--- a/src/main/java/racingcar/race/WinnersReferee.java
+++ b/src/main/java/racingcar/race/WinnersReferee.java
@@ -4,20 +4,26 @@ import racingcar.rule.Name;
 import racingcar.rule.Position;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
 public final class WinnersReferee {
 
     // TODO
     public Winners determineFrom(MoveRecords moveRecords) {
-        final Position winningPosition = moveRecords.maxPosition();
-        final List<Name> winnerNames = new ArrayList<>();
+        final Predicate<Name> isWinner = criteriaBy(moveRecords);
+        final List<Name> winners = new ArrayList<>();
         for (Name name : moveRecords.allNames()) {
-            final Position position = moveRecords.positionBy(name);
-            if (position.equals(winningPosition)) {
-                winnerNames.add(name);
+            if (isWinner.test(name)) {
+                winners.add(name);
             }
         }
-        return Winners.from(winnerNames);
+        return Winners.from(winners);
+    }
+
+    private Predicate<Name> criteriaBy(MoveRecords moveRecords) {
+        final Position winningPosition = Collections.max(moveRecords.allPositions());
+        return name -> moveRecords.positionBy(name).equals(winningPosition);
     }
 }

--- a/src/test/java/racingcar/race/MoveRecordsTest.java
+++ b/src/test/java/racingcar/race/MoveRecordsTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import racingcar.rule.Name;
 import racingcar.rule.Position;
 
+import java.util.Collection;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MoveRecordsTest {
@@ -62,9 +64,9 @@ class MoveRecordsTest {
         Name name1 = new Name("pobi");
         Name name2 = new Name("honux");
         Position position = new Position(5);
-        MoveRecords moveRecords = new MoveRecords();
 
         //when
+        MoveRecords moveRecords = new MoveRecords();
         moveRecords.recordOf(name1, position);
         moveRecords.recordOf(name2, position);
         Iterable<Name> names = moveRecords.allNames();
@@ -73,20 +75,21 @@ class MoveRecordsTest {
         assertThat(names).containsExactlyInAnyOrder(name1, name2);
     }
 
-
-    @DisplayName("기록된 최대 위치를 구할 수 있다")
+    @DisplayName("기록된 모든 위치를 구할 수 있다")
     @Test
-    void maxPosition() {
+    void allPositions() {
         //given
-        Position expectedMaxPosition = new Position(5);
-        MoveRecords moveRecords = new MoveRecords();
+        Position position1 = new Position(3);
+        Position position2 = new Position(5);
 
         //when
-        moveRecords.recordOf(new Name("pobi"), expectedMaxPosition);
-        moveRecords.recordOf(new Name("honux"), Position.start());
-        Position actual = moveRecords.maxPosition();
+        MoveRecords moveRecords = new MoveRecords();
+        moveRecords.recordOf(new Name("a"), position1);
+        moveRecords.recordOf(new Name("b"), position2);
+        moveRecords.recordOf(new Name("c"), position2);
+        Collection<Position> positions = moveRecords.allPositions();
 
         //then
-        assertThat(actual).isEqualTo(expectedMaxPosition);
+        assertThat(positions).containsExactly(position1, position2, position2);
     }
 }

--- a/src/test/java/racingcar/race/WinnersRefereeTest.java
+++ b/src/test/java/racingcar/race/WinnersRefereeTest.java
@@ -9,18 +9,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class WinnersRefereeTest {
 
-    @DisplayName("가장 먼 위치의 자동차가 우승이다")
+    @DisplayName("우승자를 판별한다")
     @Test
     void winners() {
         //given
         Name expectedWinner = new Name("crong");
         MoveRecords moveRecords = new MoveRecords();
-        moveRecords.recordOf(new Name("pobi"), new Position(1));
+        moveRecords.recordOf(new Name("name1"), new Position(1));
         moveRecords.recordOf(expectedWinner, new Position(9));
-        moveRecords.recordOf(new Name("honux"), new Position(3));
-        WinnersReferee winnersReferee = new WinnersReferee();
+        moveRecords.recordOf(new Name("name2"), new Position(3));
 
         //when
+        WinnersReferee winnersReferee = new WinnersReferee();
         Winners winners = winnersReferee.determineFrom(moveRecords);
 
         //then


### PR DESCRIPTION
### 한 일
- 이동 기록인 `MoveRecords`를 좀 더 자료구조스럽게 변경하고
- 우승 조건인 최대 거리에 대한 내용을 `WinnersReferee`로 옮겼다

### 이유
- 기존에 MoveRecords가 최대 거리인 `maxPosition()`와 모든 거리인 `allPositions()` 중 어떤걸 리턴할지 계속 고민했는데
- maxPosition()
  -  객체한테 일을 시키는 것 같음
- allPositions()
  -  keys인 allNames()가 있으니까 values인 allPositions()가 메서드 짝(?)이 맞아서 더 이해하기 좋지 않을까?
  - maxPosition()은 우승을 판별하는 조건이므로 우승판별 객체가 갖고있어야 할 개념 아닐까?
- 변경 기준
  - 클린코드 6장을 다시 읽었음
  - MoveRecords는 나에게 자료구조이고, WinnersReferee는 이 구조를 사용하면서 비즈니스 규칙을 담은 객체인게 아닐까?

### 느낀점
- 해당 챕터는 언제나 어렵고 난 항상 잡종구조를 만들어놓고 고민하는 거 같다ㅠ
